### PR TITLE
fix: Allow MAX_CACHE_SIZE=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use environment variables to set login credentials and pushover tokens:
     </tr>
     <tr>
         <th scope="row">MAX_CACHE_SIZE</td>
-        <td>Optional, to setup the living cache size, defaults to 50</td>
+        <td>Optional, to setup the living cache size, defaults to 50, set to 0 (zero) to disable the cache</td>
     </tr>
 </table>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "author": "Sebastian Pekarek <mail@sebbo.net>",
     "bin": {
-        "gitlab-badges": "./dist/bin/start.js"
+        "gitlab-badges": "./dist/start.js"
     },
     "bugs": {
         "url": "https://github.com/sebbo2002/gitlab-badges/issues"
@@ -58,10 +58,10 @@
         "build": "tsup",
         "build-all": "./.github/workflows/build.sh",
         "coverage": "c8 mocha",
-        "develop": "tsx src/bin/start.ts",
+        "develop": "tsx src/start.ts",
         "license-check": "license-checker --production --summary",
         "lint": "npx eslint . --fix && npx prettier . --write",
-        "start": "node ./dist/bin/start.js",
+        "start": "node ./dist/start.js",
         "test": "mocha"
     },
     "type": "module",


### PR DESCRIPTION
Hello
I needed to be able to disable the cache with env vars, as we display the build status in "real time" in a CMS

No breaking changes, no unit test, linter passes, doc updated
